### PR TITLE
[DEV-21670] Backport build_absolute_uri performance fix

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -18,6 +18,7 @@ from django.utils.datastructures import ImmutableList, MultiValueDict
 from django.utils.encoding import (
     escape_uri_path, force_bytes, force_str, force_text, iri_to_uri,
 )
+from django.utils.functional import cached_property
 from django.utils.http import is_same_domain, limited_parse_qsl
 from django.utils.six.moves.urllib.parse import (
     quote, urlencode, urljoin, urlsplit,
@@ -179,14 +180,27 @@ class HttpRequest(object):
             location = '//%s' % self.get_full_path()
         bits = urlsplit(location)
         if not (bits.scheme and bits.netloc):
-            current_uri = '{scheme}://{host}{path}'.format(scheme=self.scheme,
-                                                           host=self.get_host(),
-                                                           path=self.path)
-            # Join the constructed URL with the provided location, which will
-            # allow the provided ``location`` to apply query strings to the
-            # base path as well as override the host, if it begins with //
-            location = urljoin(current_uri, location)
+            # Handle the simple, most common case. If the location is absolute
+            # and a scheme or host (netloc) isn't provided, skip an expensive
+            # urljoin() as long as no path segments are '.' or '..'.
+            if (bits.path.startswith('/') and not bits.scheme and not bits.netloc and
+                    '/./' not in bits.path and '/../' not in bits.path):
+                # If location starts with '//' but has no netloc, reuse the
+                # schema and netloc from the current request. Strip the double
+                # slashes and continue as if it wasn't specified.
+                if location.startswith('//'):
+                    location = location[2:]
+                location = self._current_scheme_host + location
+            else:
+                # Join the constructed URL with the provided location, which
+                # allows the provided location to apply query strings to the
+                # base path.
+                location = urljoin(self._current_scheme_host + self.path, location)
         return iri_to_uri(location)
+
+    @cached_property
+    def _current_scheme_host(self):
+        return '{}://{}'.format(self.scheme, self.get_host())
 
     def _get_scheme(self):
         """


### PR DESCRIPTION
This backports a performance fix that is in Django 2.1 for `build_absolute_uri`. Here's the original bug: https://code.djangoproject.com/ticket/28828 and the pull request that fixes it: https://github.com/django/django/pull/9376

Our API serializers make extensive use of `URLReversalField`, and local profiling indicates that this change could result in significant performance improvements.

I opened a PR against the branch we currently point to in our webapp, but it's not clear to me that merging this would actually get it out to the webapp - since we just lock to `https://github.com/roverdotcom/django/archive/stable/rover-1.11.11.tar.gz` I don't know how it would know to grab a new version. Open to suggestions on the best way to handle that.