### PR TITLE
[DEV-34314] Fix parallel test runner pickle errors

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -142,7 +142,7 @@ with a cleaner failure message.
         Create a picklable (exc_type, exc, tb) encoding the given message.
         """
         try:
-            raise ParallelTestException(msg) from None
+            raise ParallelTestException(msg)
         except Exception:
             err = sys.exc_info()
 


### PR DESCRIPTION
Issue: https://code.djangoproject.com/ticket/29023#comment:5
Cherry-pick: https://github.com/cjerdonek/django/commit/0040040ca4fec08a9980a24f08bcad900e2b0f22

Removed `from None` on the exception raising for Python 2 compatibility. Tested in both Python 2.7 and 3.6 in parallel mode.