### PR TITLE
Merge in upstream 1.11.27

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 26, 'alpha', 0)
+VERSION = (1, 11, 26, 'final', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 24, 'final', 0)
+VERSION = (1, 11, 25, 'alpha', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 23, 'final', 0)
+VERSION = (1, 11, 24, 'alpha', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 25, 'final', 0)
+VERSION = (1, 11, 26, 'alpha', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 27, 'alpha', 0)
+VERSION = (1, 11, 27, 'final', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 25, 'alpha', 0)
+VERSION = (1, 11, 25, 'final', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 26, 'final', 0)
+VERSION = (1, 11, 27, 'alpha', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 24, 'alpha', 0)
+VERSION = (1, 11, 24, 'final', 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -16,10 +16,25 @@ from django.core.mail import EmailMultiAlternatives
 from django.template import loader
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+from django.utils.six import PY3
 from django.utils.text import capfirst
 from django.utils.translation import ugettext, ugettext_lazy as _
 
 UserModel = get_user_model()
+
+
+def _unicode_ci_compare(s1, s2):
+    """
+    Perform case-insensitive comparison of two identifiers, using the
+    recommended algorithm from Unicode Technical Report 36, section
+    2.11.2(B)(2).
+    """
+    normalized1 = unicodedata.normalize('NFKC', s1)
+    normalized2 = unicodedata.normalize('NFKC', s2)
+    if PY3:
+        return normalized1.casefold() == normalized2.casefold()
+    # lower() is the best alternative available on Python 2.
+    return normalized1.lower() == normalized2.lower()
 
 
 class ReadOnlyPasswordHashWidget(forms.Widget):
@@ -249,11 +264,16 @@ class PasswordResetForm(forms.Form):
         that prevent inactive users and users with unusable passwords from
         resetting their password.
         """
+        email_field_name = UserModel.get_email_field_name()
         active_users = UserModel._default_manager.filter(**{
-            '%s__iexact' % UserModel.get_email_field_name(): email,
+            '%s__iexact' % email_field_name: email,
             'is_active': True,
         })
-        return (u for u in active_users if u.has_usable_password())
+        return (
+            u for u in active_users
+            if u.has_usable_password() and
+            _unicode_ci_compare(email, getattr(u, email_field_name))
+        )
 
     def save(self, domain_override=None,
              subject_template_name='registration/password_reset_subject.txt',
@@ -266,6 +286,7 @@ class PasswordResetForm(forms.Form):
         user.
         """
         email = self.cleaned_data["email"]
+        email_field_name = UserModel.get_email_field_name()
         for user in self.get_users(email):
             if not domain_override:
                 current_site = get_current_site(request)
@@ -273,8 +294,9 @@ class PasswordResetForm(forms.Form):
                 domain = current_site.domain
             else:
                 site_name = domain = domain_override
+            user_email = getattr(user, email_field_name)
             context = {
-                'email': email,
+                'email': user_email,
                 'domain': domain,
                 'site_name': site_name,
                 'uid': urlsafe_base64_encode(force_bytes(user.pk)),
@@ -286,7 +308,7 @@ class PasswordResetForm(forms.Form):
                 context.update(extra_email_context)
             self.send_mail(
                 subject_template_name, email_template_name, context, from_email,
-                email, html_email_template_name=html_email_template_name,
+                user_email, html_email_template_name=html_email_template_name,
             )
 
 

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -86,7 +86,7 @@ class KeyTransform(Transform):
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)
-        return '(%s -> %%s)' % lhs, [self.key_name] + params
+        return '(%s -> %%s)' % lhs, params + [self.key_name]
 
 
 class KeyTransformFactory(object):

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -86,7 +86,7 @@ class KeyTransform(Transform):
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)
-        return '(%s -> %%s)' % lhs, params + [self.key_name]
+        return '(%s -> %%s)' % lhs, tuple(params) + (self.key_name,)
 
 
 class KeyTransformFactory(object):

--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -107,7 +107,7 @@ class KeyTransform(Transform):
             lookup = int(self.key_name)
         except ValueError:
             lookup = self.key_name
-        return '(%s %s %%s)' % (lhs, self.operator), [lookup] + params
+        return '(%s %s %%s)' % (lhs, self.operator), params + [lookup]
 
 
 class KeyTextTransform(KeyTransform):

--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -107,7 +107,7 @@ class KeyTransform(Transform):
             lookup = int(self.key_name)
         except ValueError:
             lookup = self.key_name
-        return '(%s %s %%s)' % (lhs, self.operator), params + [lookup]
+        return '(%s %s %%s)' % (lhs, self.operator), tuple(params) + (lookup,)
 
 
 class KeyTextTransform(KeyTransform):

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -8,7 +8,7 @@ class PostgresSimpleLookup(Lookup):
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
+        params = tuple(lhs_params) + tuple(rhs_params)
         return '%s %s %s' % (lhs, self.operator, rhs), params
 
 

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -508,6 +508,8 @@ class CheckboxInput(Input):
         if self.check_test(value):
             if attrs is None:
                 attrs = {}
+            else:
+                attrs = attrs.copy()
             attrs['checked'] = True
         return super(CheckboxInput, self).get_context(name, value, attrs)
 

--- a/docs/releases/1.11.24.txt
+++ b/docs/releases/1.11.24.txt
@@ -1,0 +1,15 @@
+============================
+Django 1.11.24 release notes
+============================
+
+*Expected September 2, 2019*
+
+Django 1.11.24 fixes a regression in 1.11.23.
+
+Bugfixes
+========
+
+* Fixed crash of ``KeyTransform()`` for
+  :class:`~django.contrib.postgres.fields.JSONField` and
+  :class:`~django.contrib.postgres.fields.HStoreField` when using on
+  expressions with params (:ticket:`30672`).

--- a/docs/releases/1.11.24.txt
+++ b/docs/releases/1.11.24.txt
@@ -2,7 +2,7 @@
 Django 1.11.24 release notes
 ============================
 
-*Expected September 2, 2019*
+*September 2, 2019*
 
 Django 1.11.24 fixes a regression in 1.11.23.
 

--- a/docs/releases/1.11.25.txt
+++ b/docs/releases/1.11.25.txt
@@ -2,7 +2,7 @@
 Django 1.11.25 release notes
 ============================
 
-*Expected October 1, 2019*
+*October 1, 2019*
 
 Django 1.11.25 fixes a regression in 1.11.23.
 

--- a/docs/releases/1.11.25.txt
+++ b/docs/releases/1.11.25.txt
@@ -1,0 +1,12 @@
+============================
+Django 1.11.25 release notes
+============================
+
+*Expected October 1, 2019*
+
+Django 1.11.25 fixes a regression in 1.11.23.
+
+Bugfixes
+========
+
+* ...

--- a/docs/releases/1.11.25.txt
+++ b/docs/releases/1.11.25.txt
@@ -9,4 +9,6 @@ Django 1.11.25 fixes a regression in 1.11.23.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when filtering with a ``Subquery()`` annotation of a queryset
+  containing :class:`~django.contrib.postgres.fields.JSONField` or
+  :class:`~django.contrib.postgres.fields.HStoreField` (:ticket:`30769`).

--- a/docs/releases/1.11.26.txt
+++ b/docs/releases/1.11.26.txt
@@ -9,4 +9,7 @@ Django 1.11.26 fixes a regression in 1.11.25.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when using a ``contains``, ``contained_by``, ``has_key``,
+  ``has_keys``, or ``has_any_keys`` lookup on
+  :class:`~django.contrib.postgres.fields.JSONField`, if the right or left hand
+  side of an expression is a key transform (:ticket:`30826`).

--- a/docs/releases/1.11.26.txt
+++ b/docs/releases/1.11.26.txt
@@ -2,7 +2,7 @@
 Django 1.11.26 release notes
 ============================
 
-*Expected November 1, 2019*
+*November 4, 2019*
 
 Django 1.11.26 fixes a regression in 1.11.25.
 

--- a/docs/releases/1.11.26.txt
+++ b/docs/releases/1.11.26.txt
@@ -1,0 +1,12 @@
+============================
+Django 1.11.26 release notes
+============================
+
+*Expected November 1, 2019*
+
+Django 1.11.26 fixes a regression in 1.11.25.
+
+Bugfixes
+========
+
+* ...

--- a/docs/releases/1.11.27.txt
+++ b/docs/releases/1.11.27.txt
@@ -1,0 +1,15 @@
+============================
+Django 1.11.27 release notes
+============================
+
+*Expected January 2, 2020*
+
+Django 1.11.27 fixes a data loss bug in 1.11.26.
+
+Bugfixes
+========
+
+* Fixed a data loss possibility in
+  :class:`~django.contrib.postgres.forms.SplitArrayField`. When using with
+  ``ArrayField(BooleanField())``, all values after the first ``True`` value
+  were marked as checked instead of preserving passed values (:ticket:`31073`).

--- a/docs/releases/1.11.27.txt
+++ b/docs/releases/1.11.27.txt
@@ -2,9 +2,25 @@
 Django 1.11.27 release notes
 ============================
 
-*Expected January 2, 2020*
+*December 18, 2019*
 
-Django 1.11.27 fixes a data loss bug in 1.11.26.
+Django 1.11.27 fixes a security issue and a data loss bug in 1.11.26.
+
+CVE-2019-19844: Potential account hijack via password reset form
+================================================================
+
+By submitting a suitably crafted email address making use of Unicode
+characters, that compared equal to an existing user email when lower-cased for
+comparison, an attacker could be sent a password reset token for the matched
+account.
+
+In order to avoid this vulnerability, password reset requests now compare the
+submitted email using the stricter, recommended algorithm for case-insensitive
+comparison of two identifiers from `Unicode Technical Report 36, section
+2.11.2(B)(2)`__. Upon a match, the email containing the reset token will be
+sent to the email address on record rather than the submitted address.
+
+.. __: https://www.unicode.org/reports/tr36/#Recommendations_General
 
 Bugfixes
 ========

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -26,6 +26,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.11.25
    1.11.24
    1.11.23
    1.11.22

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -26,6 +26,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.11.24
    1.11.23
    1.11.22
    1.11.21

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -26,6 +26,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.11.26
    1.11.25
    1.11.24
    1.11.23

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -26,6 +26,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.11.27
    1.11.26
    1.11.25
    1.11.24

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -974,3 +974,16 @@ Versions affected
 * Django 2.2 :commit:`(patch) <77706a3e4766da5d5fb75c4db22a0a59a28e6cd6>`
 * Django 2.1 :commit:`(patch) <1e40f427bb8d0fb37cc9f830096a97c36c97af6f>`
 * Django 1.11 :commit:`(patch) <32124fc41e75074141b05f10fc55a4f01ff7f050>`
+
+August 1, 2019 - :cve:`2019-14232`
+----------------------------------
+
+Denial-of-service possibility in ``django.utils.text.Truncator``. `Full
+description <https://www.djangoproject.com/weblog/2019/aug/01/security-releases/>`__
+
+Versions affected
+~~~~~~~~~~~~~~~~~
+
+* Django 2.2 :commit:`(patch) <c3289717c6f21a8cf23daff1c78c0c014b94041f>`
+* Django 2.1 :commit:`(patch) <c23723a1551340cc7d3126f04fcfd178fa224193>`
+* Django 1.11 :commit:`(patch) <42a66e969023c00536256469f0e8b8a099ef109d>`

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -1015,3 +1015,17 @@ Versions affected
 * Django 2.2 :commit:`(patch) <4f5b58f5cd3c57fee9972ab074f8dc6895d8f387>`
 * Django 2.1 :commit:`(patch) <f74b3ae3628c26e1b4f8db3d13a91d52a833a975>`
 * Django 1.11 :commit:`(patch) <ed682a24fca774818542757651bfba576c3fc3ef>`
+
+August 1, 2019 - :cve:`2019-14235`
+----------------------------------
+
+Potential memory exhaustion in ``django.utils.encoding.uri_to_iri()``. `Full
+description
+<https://www.djangoproject.com/weblog/2019/aug/01/security-releases/>`__
+
+Versions affected
+~~~~~~~~~~~~~~~~~
+
+* Django 2.2 :commit:`(patch) <cf694e6852b0da7799f8b53f1fb2f7d20cf17534>`
+* Django 2.1 :commit:`(patch) <5d50a2e5fa36ad23ab532fc54cf4073de84b3306>`
+* Django 1.11 :commit:`(patch) <869b34e9b3be3a4cfcb3a145f218ffd3f5e3fd79>`

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -987,3 +987,16 @@ Versions affected
 * Django 2.2 :commit:`(patch) <c3289717c6f21a8cf23daff1c78c0c014b94041f>`
 * Django 2.1 :commit:`(patch) <c23723a1551340cc7d3126f04fcfd178fa224193>`
 * Django 1.11 :commit:`(patch) <42a66e969023c00536256469f0e8b8a099ef109d>`
+
+August 1, 2019 - :cve:`2019-14233`
+----------------------------------
+
+Denial-of-service possibility in ``strip_tags()``. `Full description
+<https://www.djangoproject.com/weblog/2019/aug/01/security-releases/>`__
+
+Versions affected
+~~~~~~~~~~~~~~~~~
+
+* Django 2.2 :commit:`(patch) <e34f3c0e9ee5fc9022428fe91640638bafd4cda7>`
+* Django 2.1 :commit:`(patch) <5ff8e791148bd451180124d76a55cb2b2b9556eb>`
+* Django 1.11 :commit:`(patch) <52479acce792ad80bb0f915f20b835f919993c72>`

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -1000,3 +1000,18 @@ Versions affected
 * Django 2.2 :commit:`(patch) <e34f3c0e9ee5fc9022428fe91640638bafd4cda7>`
 * Django 2.1 :commit:`(patch) <5ff8e791148bd451180124d76a55cb2b2b9556eb>`
 * Django 1.11 :commit:`(patch) <52479acce792ad80bb0f915f20b835f919993c72>`
+
+
+August 1, 2019 - :cve:`2019-14234`
+----------------------------------
+
+SQL injection possibility in key and index lookups for
+``JSONField``/``HStoreField``. `Full description
+<https://www.djangoproject.com/weblog/2019/aug/01/security-releases/>`__
+
+Versions affected
+~~~~~~~~~~~~~~~~~
+
+* Django 2.2 :commit:`(patch) <4f5b58f5cd3c57fee9972ab074f8dc6895d8f387>`
+* Django 2.1 :commit:`(patch) <f74b3ae3628c26e1b4f8db3d13a91d52a833a975>`
+* Django 1.11 :commit:`(patch) <ed682a24fca774818542757651bfba576c3fc3ef>`

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -694,6 +694,48 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form['email'].errors, [_('Enter a valid email address.')])
 
+    def test_user_email_unicode_collision(self):
+        User.objects.create_user('mike123', 'mike@example.org', 'test123')
+        User.objects.create_user('mike456', 'mıke@example.org', 'test123')
+        data = {'email': 'mıke@example.org'}
+        form = PasswordResetForm(data)
+        if six.PY2:
+            self.assertFalse(form.is_valid())
+        else:
+            self.assertTrue(form.is_valid())
+            form.save()
+            self.assertEqual(len(mail.outbox), 1)
+            self.assertEqual(mail.outbox[0].to, ['mıke@example.org'])
+
+    def test_user_email_domain_unicode_collision(self):
+        User.objects.create_user('mike123', 'mike@ixample.org', 'test123')
+        User.objects.create_user('mike456', 'mike@ıxample.org', 'test123')
+        data = {'email': 'mike@ıxample.org'}
+        form = PasswordResetForm(data)
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['mike@ıxample.org'])
+
+    def test_user_email_unicode_collision_nonexistent(self):
+        User.objects.create_user('mike123', 'mike@example.org', 'test123')
+        data = {'email': 'mıke@example.org'}
+        form = PasswordResetForm(data)
+        if six.PY2:
+            self.assertFalse(form.is_valid())
+        else:
+            self.assertTrue(form.is_valid())
+            form.save()
+            self.assertEqual(len(mail.outbox), 0)
+
+    def test_user_email_domain_unicode_collision_nonexistent(self):
+        User.objects.create_user('mike123', 'mike@ixample.org', 'test123')
+        data = {'email': 'mike@ıxample.org'}
+        form = PasswordResetForm(data)
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEqual(len(mail.outbox), 0)
+
     def test_nonexistent_email(self):
         """
         Test nonexistent email address. This should not fail because it would

--- a/tests/forms_tests/widget_tests/test_checkboxinput.py
+++ b/tests/forms_tests/widget_tests/test_checkboxinput.py
@@ -89,3 +89,8 @@ class CheckboxInputTest(WidgetTest):
     def test_value_omitted_from_data(self):
         self.assertIs(self.widget.value_omitted_from_data({'field': 'value'}, {}, 'field'), False)
         self.assertIs(self.widget.value_omitted_from_data({}, {}, 'field'), False)
+
+    def test_get_context_does_not_mutate_attrs(self):
+        attrs = {'checked': False}
+        self.widget.get_context('name', True, attrs)
+        self.assertIs(attrs['checked'], False)

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -826,6 +826,17 @@ class TestSplitFormWidget(PostgreSQLWidgetTestCase):
             }
         )
 
+    def test_checkbox_get_context_attrs(self):
+        context = SplitArrayWidget(
+            forms.CheckboxInput(),
+            size=2,
+        ).get_context('name', [True, False])
+        self.assertEqual(context['widget']['value'], '[True, False]')
+        self.assertEqual(
+            [subwidget['attrs'] for subwidget in context['widget']['subwidgets']],
+            [{'checked': True}, {}]
+        )
+
     def test_render(self):
         self.check_html(
             SplitArrayWidget(forms.TextInput(), size=2), 'array', None,

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -5,6 +5,7 @@ import json
 
 from django.core import exceptions, serializers
 from django.db import connection
+from django.db.models.expressions import RawSQL
 from django.forms import Form
 from django.test.utils import CaptureQueriesContext, modify_settings
 
@@ -14,6 +15,7 @@ from .models import HStoreModel
 try:
     from django.contrib.postgres import forms
     from django.contrib.postgres.fields import HStoreField
+    from django.contrib.postgres.fields.hstore import KeyTransform
     from django.contrib.postgres.validators import KeysValidator
 except ImportError:
     pass
@@ -118,6 +120,13 @@ class TestQuerying(HStoreTestCase):
     def test_key_transform(self):
         self.assertSequenceEqual(
             HStoreModel.objects.filter(field__a='b'),
+            self.objs[:2]
+        )
+
+    def test_key_transform_raw_expression(self):
+        expr = RawSQL('%s::hstore', ['x => b, y => c'])
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__a=KeyTransform('x', expr)),
             self.objs[:2]
         )
 

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -5,7 +5,7 @@ import json
 
 from django.core import exceptions, serializers
 from django.db import connection
-from django.db.models.expressions import RawSQL
+from django.db.models.expressions import OuterRef, RawSQL, Subquery
 from django.forms import Form
 from django.test.utils import CaptureQueriesContext, modify_settings
 
@@ -188,6 +188,12 @@ class TestQuerying(HStoreTestCase):
             """."field" -> 'test'' = ''a'') OR 1 = 1 OR (''d') = 'x' """,
             queries[0]['sql'],
         )
+
+    def test_obj_subquery_lookup(self):
+        qs = HStoreModel.objects.annotate(
+            value=Subquery(HStoreModel.objects.filter(pk=OuterRef('pk')).values('field')),
+        ).filter(value__a='b')
+        self.assertSequenceEqual(qs, self.objs[:2])
 
 
 class TestSerialization(HStoreTestCase):

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from django.core import exceptions, serializers
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection
-from django.db.models import F
+from django.db.models import F, OuterRef, Subquery
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Cast
 from django.forms import CharField, Form, widgets
@@ -221,6 +221,12 @@ class TestQuerying(PostgreSQLTestCase):
             JSONModel.objects.filter(field__a='b'),
             [self.objs[7], self.objs[8]]
         )
+
+    def test_obj_subquery_lookup(self):
+        qs = JSONModel.objects.annotate(
+            value=Subquery(JSONModel.objects.filter(pk=OuterRef('pk')).values('field')),
+        ).filter(value__a='b')
+        self.assertSequenceEqual(qs, [self.objs[7], self.objs[8]])
 
     def test_deep_lookup_objs(self):
         self.assertSequenceEqual(


### PR DESCRIPTION
This includes mitigation for CVE CVE-2019-19844: https://www.djangoproject.com/weblog/2019/dec/18/security-releases/

I created branch `stable/rover-1.11.27` off of `stable/rover-1.11.23`, then did a `git merge 1.11.27` which is the upstream tag. Verified as follows:

```
git log --oneline stable/rover-1.11.23..HEAD
940b036d75 (HEAD -> aiden/patch-1.11.27) Merge tag '1.11.27' into aiden/patch-1.11.27
358973a12e (tag: 1.11.27) [1.11.x] Bumped version for 1.11.27 release.
f4cff43bf9 [1.11.x] Fixed CVE-2019-19844 -- Used verified user email for password reset requests.
a2355740ed [1.11.x] Refs #31073 -- Added release notes for 02eff7ef60466da108b1a33f1e4dc01eec45c99d.
e8fdf00cc2 [1.11.x] Fixed #31073 -- Prevented CheckboxInput.get_context() from mutating attrs.
4f1501660b [1.11.x] Post-release version bump.
f24d305761 (tag: 1.11.26) [1.11.x] Bumped version for 1.11.26 release.
4017507660 [1.11.x] Added release date for 1.11.26.
a843a9ba8d [1.11.x] Fixed #30826 -- Fixed crash of many JSONField lookups when one hand side is key transform.
cf2b475aab [1.11.x] Added stub release notes for 1.11.26.
b73bb46d42 [1.11.x] Post-release version bump.
81f0da91fb (tag: 1.11.25) [1.11.x] Bumped version for 1.11.25 release.
9d2916faf5 [1.11.x] Added release date for 1.11.25.
fd393907c9 [1.11.x] Fixed #30769 -- Fixed a crash when filtering against a subquery JSON/HStoreField annotation.
30c3d5fd73 [1.11.x] Added stub release notes for 1.11.25.
f213c4c406 [1.11.x] Post-release version bump.
4c049c805a (tag: 1.11.24) [1.11.x] Bumped version for 1.11.24 release.
835b62a588 [1.11.x] Added release date for 1.11.24.
473c526b1b [1.11.x] Fixed #30672 -- Fixed crash of JSONField/HStoreField key transforms on expressions with params.
3deda1f680 [1.11.x] Added CVE-2019-14235 to security release archive.
738b45dd3b [1.11.x] Added CVE-2019-14234 to security release archive.
7482d25f1e [1.11.x] Added CVE-2019-14233 to security release archive.
ba791617e0 [1.11.x] Added CVE-2019-14232 to the security release archive.
1e6a5b0001 [1.11.x] Post-release version bump.
```