### PR TITLE
CVE-2020-13596: Possible XSS via admin `ForeignKeyRawIdWidget`

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -14,7 +14,7 @@ from django.urls.exceptions import NoReverseMatch
 from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.html import smart_urlquote
-from django.utils.safestring import mark_safe
+from django.utils.http import urlencode
 from django.utils.text import Truncator
 from django.utils.translation import ugettext as _
 
@@ -149,8 +149,8 @@ class ForeignKeyRawIdWidget(forms.TextInput):
 
             params = self.url_parameters()
             if params:
-                related_url += '?' + '&amp;'.join('%s=%s' % (k, v) for k, v in params.items())
-            context['related_url'] = mark_safe(related_url)
+                related_url += '?' + urlencode(params)
+            context['related_url'] = related_url
             context['link_title'] = _('Lookup')
             # The JavaScript code looks for this class.
             context['widget']['attrs'].setdefault('class', 'vForeignKeyRawIdAdminField')

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -33,6 +33,15 @@ class Band(models.Model):
 
 
 @python_2_unicode_compatible
+class UnsafeLimitChoicesTo(models.Model):
+    band = models.ForeignKey(
+        Band,
+        models.CASCADE,
+        limit_choices_to={'name': '"&><escapeme'},
+    )
+
+
+@python_2_unicode_compatible
 class Album(models.Model):
     band = models.ForeignKey(Band, models.CASCADE)
     name = models.CharField(max_length=100)

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -24,7 +24,7 @@ from django.utils import six, translation
 
 from .models import (
     Advisor, Album, Band, Bee, Car, Company, Event, Honeycomb, Individual,
-    Inventory, Member, MyFileField, Profile, School, Student,
+    Inventory, Member, MyFileField, Profile, School, Student, UnsafeLimitChoicesTo,
 )
 from .widgetadmin import site as widget_admin_site
 
@@ -572,6 +572,16 @@ class ForeignKeyRawIdWidgetTest(TestCase):
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
             '&nbsp;<strong><a href="/admin_widgets/inventory/%(pk)s/change/">'
             'Hidden</a></strong>' % {'pk': hidden.pk}
+        )
+
+    def test_render_unsafe_limit_choices_to(self):
+        rel = UnsafeLimitChoicesTo._meta.get_field('band').remote_field
+        w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
+        self.assertHTMLEqual(
+            w.render('test', None),
+            '<input type="text" name="test" class="vForeignKeyRawIdAdminField">\n'
+            '<a href="/admin_widgets/band/?name=%22%26%3E%3Cescapeme&amp;_to_field=id" '
+            'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
         )
 
 


### PR DESCRIPTION
================================================================

Query parameters for the admin `ForeignKeyRawIdWidget` were not properly URL
encoded, posing an XSS attack vector. `ForeignKeyRawIdWidget` now
ensures query parameters are correctly URL encoded.

Here is the official patch, which was not ported to 1.11: https://github.com/django/django/commit/6d61860b22875f358fac83d903dc629897934815